### PR TITLE
Add minimal FAISS-based FastAPI service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# ThemaLite-Solo
+
+ThemaLite-Solo is a minimal FastAPI service that demonstrates vector search and summarisation
+using a small in-repository dataset. It loads company blurbs, embeds them with a
+Sentence Transformer model and performs nearest neighbour search with FAISS.
+
+## Quickstart
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+### Search
+```bash
+curl "http://127.0.0.1:8000/search?q=fintech compliance&k=5"
+```
+
+### Summary
+```bash
+curl "http://127.0.0.1:8000/summary?q=enterprise AI for retail"
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,56 @@
+import faiss
+import numpy as np
+import pandas as pd
+from fastapi import FastAPI
+from pathlib import Path
+from sentence_transformers import SentenceTransformer
+
+DATA_PATH = Path(__file__).parent / "data" / "companies.csv"
+
+# Load dataset
+companies = pd.read_csv(DATA_PATH)
+
+# Build embeddings and FAISS index
+model = SentenceTransformer("all-MiniLM-L6-v2")
+embeddings = model.encode(companies["blurb"].tolist(), convert_to_numpy=True)
+faiss.normalize_L2(embeddings)
+index = faiss.IndexFlatIP(embeddings.shape[1])
+index.add(embeddings)
+
+app = FastAPI()
+
+
+def _search(query: str, k: int):
+    query_vec = model.encode([query], convert_to_numpy=True)
+    faiss.normalize_L2(query_vec)
+    scores, ids = index.search(query_vec, k)
+    results = []
+    for score, idx in zip(scores[0], ids[0]):
+        row = companies.iloc[idx]
+        results.append({
+            "id": int(row["id"]),
+            "name": row["name"],
+            "blurb": row["blurb"],
+            "sector": row["sector"],
+            "score": float(score),
+        })
+    return results
+
+
+@app.get("/search")
+def search(q: str, k: int = 5):
+    return {"results": _search(q, k)}
+
+
+@app.get("/summary")
+def summary(q: str):
+    neighbors = _search(q, 3)
+    pieces = [f"{n['name']} ({n['sector']})" for n in neighbors]
+    text = f"Companies similar to '{q}' include " + ", ".join(pieces) + "."
+    return {"summary": text, "neighbors": neighbors}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/data/companies.csv
+++ b/data/companies.csv
@@ -1,0 +1,6 @@
+id,name,blurb,sector
+1,FinGuard,"AI-powered compliance platform for fintech companies",Fintech
+2,ShopAI,"Retail analytics for optimizing inventory and sales",Retail
+3,HealthEase,"Telemedicine solution connecting patients to doctors",Healthcare
+4,GreenGrid,"Smart grid technology for renewable energy integration",Energy
+5,AutoPilot,"Autonomous driving software for commercial vehicles",Automotive

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+sentence-transformers
+torch
+faiss-cpu
+pandas


### PR DESCRIPTION
## Summary
- remove placeholder file
- add FastAPI application that embeds company blurbs and exposes `/search` and `/summary` endpoints
- include tiny sample dataset and quickstart instructions

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5ebf03538832caeba626a5ab77bd9